### PR TITLE
Fix oversight for boards with multiple i2c interfaces

### DIFF
--- a/src/Tomoto_HM330X.cpp
+++ b/src/Tomoto_HM330X.cpp
@@ -3,7 +3,7 @@
 Tomoto_HM330X::Tomoto_HM330X(uint8_t addr) : Tomoto_HM330X(Wire, addr) {}
 
 Tomoto_HM330X::Tomoto_HM330X(TwoWire& wire, uint8_t addr)
-    : m_wire(Wire), m_addr(addr), std(m_data), atm(m_data), count(m_data) {}
+    : m_wire(wire), m_addr(addr), std(m_data), atm(m_data), count(m_data) {}
 
 bool Tomoto_HM330X::begin(bool retry) {
   m_wire.begin();


### PR DESCRIPTION
For example, esp32-s3 (Wire, Wire1)
One small character -> subtle problem with multi-i2c interface boards.